### PR TITLE
Expose mfe button

### DIFF
--- a/apps/common/src/app/components/mfe-button/mfe-button.ts
+++ b/apps/common/src/app/components/mfe-button/mfe-button.ts
@@ -1,0 +1,1 @@
+export { MfeButtonComponent as default } from '../mfe-button.component';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -22,6 +22,9 @@
             "common/Routes": [
                 "apps/common/src/app/remote-entry/entry.routes.ts"
             ],
+            "common/MfeButton": [
+                "apps/common/src/app/components/mfe-button/mfe-button.ts"
+            ],
             "product-ui/Routes": [
                 "apps/product-ui/src/app/remote-entry/entry.routes.ts"
             ]


### PR DESCRIPTION
## Summary
- expose `MfeButton` from `common` so other apps can import it

## Testing
- `npm test` *(fails: Missing script)*
- `npx nx test` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684f96d1ed1483239a4cb15dff1f7bb2