### PR TITLE
Add officer dashboard with auth guard

### DIFF
--- a/apps/auth-ui/src/app/pages/login/login.component.ts
+++ b/apps/auth-ui/src/app/pages/login/login.component.ts
@@ -1,0 +1,30 @@
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { SharedButtonComponent } from 'shared/ButtonComponent';
+import { SharedInputComponent } from 'shared/InputComponent';
+
+@Component({
+  standalone: true,
+  selector: 'auth-login-page',
+  imports: [CommonModule, FormsModule, SharedButtonComponent, SharedInputComponent],
+  template: `
+    <h2>Login</h2>
+    <form (ngSubmit)="login()">
+      <shared-input placeholder="Username" [(ngModel)]="username" name="username"></shared-input>
+      <shared-input placeholder="Password" type="password" [(ngModel)]="password" name="password"></shared-input>
+      <shared-button>Login</shared-button>
+    </form>
+  `,
+})
+export class LoginComponent {
+  username = '';
+  password = '';
+  constructor(private router: Router) {}
+  login() {
+    // simple demo login: store role in localStorage
+    localStorage.setItem('userRole', 'officer');
+    this.router.navigate(['/dashboard']);
+  }
+}

--- a/apps/auth-ui/src/app/remote-entry/entry.routes.ts
+++ b/apps/auth-ui/src/app/remote-entry/entry.routes.ts
@@ -1,6 +1,8 @@
 import { Route } from '@angular/router';
 import { RemoteEntryComponent } from './entry.component';
+import { LoginComponent } from '../pages/login/login.component';
 
 export const remoteRoutes: Route[] = [
   { path: '', component: RemoteEntryComponent },
+  { path: 'login', component: LoginComponent },
 ];

--- a/apps/storefront/src/app/app.component.html
+++ b/apps/storefront/src/app/app.component.html
@@ -3,6 +3,7 @@
     <li><a routerLink="auth-ui">AuthUi</a></li>
     <li><a routerLink="product-ui">ProductUi</a></li>
     <li><a routerLink="cart">Cart</a></li>
+    <li><a routerLink="dashboard">Dashboard</a></li>
 </ul>
 <shared-button>Something</shared-button>
 <router-outlet></router-outlet>

--- a/apps/storefront/src/app/app.routes.ts
+++ b/apps/storefront/src/app/app.routes.ts
@@ -1,8 +1,17 @@
 import { NxWelcomeComponent } from './nx-welcome.component';
 import { Route } from '@angular/router';
+import { officerGuard } from './guards/officer.guard';
 import { CartPipelineComponent } from './pipelines/cart-pipeline/cart-pipeline.component';
 
 export const appRoutes: Route[] = [
+    {
+        path: 'dashboard',
+        canActivate: [officerGuard],
+        loadChildren: () =>
+            import('./pages/dashboard/dashboard.routes').then(
+                (m) => m.dashboardRoutes
+            ),
+    },
     {
         path: 'product-ui',
         loadChildren: () =>

--- a/apps/storefront/src/app/guards/officer.guard.ts
+++ b/apps/storefront/src/app/guards/officer.guard.ts
@@ -1,0 +1,11 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+
+export const officerGuard: CanActivateFn = () => {
+  const router = inject(Router);
+  const role = localStorage.getItem('userRole');
+  if (role === 'officer') {
+    return true;
+  }
+  return router.parseUrl('/auth-ui/login');
+};

--- a/apps/storefront/src/app/pages/dashboard/dashboard.component.ts
+++ b/apps/storefront/src/app/pages/dashboard/dashboard.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  standalone: true,
+  selector: 'storefront-dashboard',
+  imports: [CommonModule],
+  template: `
+    <h1 class="title">Dashboard</h1>
+    <p>Welcome to the dashboard page. This is a placeholder for TailAdmin dashboard.</p>
+  `,
+})
+export class DashboardComponent {}

--- a/apps/storefront/src/app/pages/dashboard/dashboard.routes.ts
+++ b/apps/storefront/src/app/pages/dashboard/dashboard.routes.ts
@@ -1,0 +1,6 @@
+import { Route } from '@angular/router';
+import { DashboardComponent } from './dashboard.component';
+
+export const dashboardRoutes: Route[] = [
+  { path: '', component: DashboardComponent },
+];


### PR DESCRIPTION
## Summary
- add login page to auth-ui
- secure dashboard route with officer guard
- add simple dashboard page
- link to the dashboard from the store menu

## Testing
- `npx nx lint auth-ui` *(fails: needs `nx` package)*
- `npx tsc -p apps/storefront/tsconfig.app.json --noEmit` *(fails: missing Angular packages)*

------
https://chatgpt.com/codex/tasks/task_e_68512bdfe03c8323936130bb6468ede1