### PR TITLE
Implement cart component MF export

### DIFF
--- a/apps/cart/module-federation.config.ts
+++ b/apps/cart/module-federation.config.ts
@@ -5,6 +5,7 @@ const config: ModuleFederationConfig = {
 
     exposes: {
         './Module': './src/remote-entry.ts',
+        './CartComponent': './src/app/components/cart.compoent.tsx',
     },
 };
 

--- a/apps/cart/src/app/components/cart.compoent.tsx
+++ b/apps/cart/src/app/components/cart.compoent.tsx
@@ -1,6 +1,23 @@
-const CartCompoent = () => {
-    return (<> Your cart</>)
-}
+import { useEffect, useState } from 'react';
 
+export const CART_COUNT_EVENT = 'cart-count-change';
+
+const CartCompoent = () => {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent).detail;
+      if (detail && typeof detail.count === 'number') {
+        setCount(detail.count);
+      }
+    };
+
+    window.addEventListener(CART_COUNT_EVENT, handler);
+    return () => window.removeEventListener(CART_COUNT_EVENT, handler);
+  }, []);
+
+  return <span>{count}</span>;
+};
 
 export default CartCompoent;


### PR DESCRIPTION
## Summary
- add a new `CartComponent` to display cart count
- expose `CartComponent` in cart's module federation config

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6853f914799883239b26d0f27b53d73b