### PR TITLE
Add Firebase admin auth module

### DIFF
--- a/apps/auth/src/app/app.module.ts
+++ b/apps/auth/src/app/app.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { AuthModule } from './auth.module';
 
 @Module({
-  imports: [],
+  imports: [AuthModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/apps/auth/src/app/auth.controller.ts
+++ b/apps/auth/src/app/auth.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get, Req, UseGuards } from '@nestjs/common';
+import { FirebaseAuthGuard } from './firebase-auth.guard';
+import { Request } from 'express';
+
+@Controller()
+export class AuthController {
+  @Get('profile')
+  @UseGuards(FirebaseAuthGuard)
+  getProfile(@Req() req: Request) {
+    return (req as any).user;
+  }
+}

--- a/apps/auth/src/app/auth.module.ts
+++ b/apps/auth/src/app/auth.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { FirebaseAdminService } from './firebase-admin.service';
+import { FirebaseAuthGuard } from './firebase-auth.guard';
+import { AuthController } from './auth.controller';
+
+@Module({
+  controllers: [AuthController],
+  providers: [FirebaseAdminService, FirebaseAuthGuard],
+  exports: [FirebaseAdminService, FirebaseAuthGuard],
+})
+export class AuthModule {}

--- a/apps/auth/src/app/firebase-admin.service.ts
+++ b/apps/auth/src/app/firebase-admin.service.ts
@@ -1,0 +1,36 @@
+import { Injectable, Logger } from '@nestjs/common';
+import * as admin from 'firebase-admin';
+import { readFileSync } from 'fs';
+
+@Injectable()
+export class FirebaseAdminService {
+  private app: admin.app.App;
+  public auth: admin.auth.Auth;
+
+  constructor() {
+    if (admin.apps.length === 0) {
+      const serviceAccountPath = process.env.FIREBASE_SERVICE_ACCOUNT_PATH;
+      let credential: admin.ServiceAccount | undefined;
+      try {
+        if (serviceAccountPath) {
+          const file = readFileSync(serviceAccountPath, 'utf8');
+          credential = JSON.parse(file);
+        } else if (process.env.FIREBASE_PROJECT_ID) {
+          credential = {
+            projectId: process.env.FIREBASE_PROJECT_ID,
+            clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+            privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
+          } as admin.ServiceAccount;
+        }
+      } catch (err) {
+        Logger.error('Failed to load Firebase credentials', err as any);
+      }
+      this.app = admin.initializeApp({
+        credential: credential ? admin.credential.cert(credential) : undefined,
+      });
+    } else {
+      this.app = admin.app();
+    }
+    this.auth = this.app.auth();
+  }
+}

--- a/apps/auth/src/app/firebase-auth.guard.ts
+++ b/apps/auth/src/app/firebase-auth.guard.ts
@@ -1,0 +1,43 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException, ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Request } from 'express';
+import { FirebaseAdminService } from './firebase-admin.service';
+
+@Injectable()
+export class FirebaseAuthGuard implements CanActivate {
+  constructor(
+    private readonly firebase: FirebaseAdminService,
+    private readonly reflector: Reflector,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<Request>();
+    const authHeader = request.headers['authorization'] || request.headers['Authorization'];
+    if (!authHeader) {
+      throw new UnauthorizedException('Authorization header missing');
+    }
+    const match = /^Bearer\s+(.*)$/.exec(Array.isArray(authHeader) ? authHeader[0] : authHeader);
+    if (!match) {
+      throw new UnauthorizedException('Invalid authorization header');
+    }
+    const token = match[1];
+    try {
+      const decoded = await this.firebase.auth.verifyIdToken(token);
+      (request as any).user = decoded;
+      const requiredRoles = this.reflector.getAllAndOverride<string[]>('roles', [
+        context.getHandler(),
+        context.getClass(),
+      ]);
+      if (requiredRoles && requiredRoles.length) {
+        const userRoles: string[] = (decoded as any).roles || (decoded as any).role ? [ (decoded as any).role ] : [];
+        const hasRole = requiredRoles.some((role) => userRoles.includes(role));
+        if (!hasRole) {
+          throw new ForbiddenException('Insufficient role');
+        }
+      }
+      return true;
+    } catch (err) {
+      throw new UnauthorizedException('Invalid token');
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "@nestjs/swagger": "7.4.0",
         "@nestjs/throttler": "6.2.1",
         "axios": "1.6.0",
+        "firebase-admin": "^13.4.0",
         "mongoose": "8.6.3",
         "react": "18.3.1",
         "react-dom": "18.3.1",


### PR DESCRIPTION
## Summary
- install firebase-admin
- set up `AuthModule` with firebase admin service
- implement custom `FirebaseAuthGuard`
- add `/profile` route protected with the guard

## Testing
- `npx tsc -p apps/auth/tsconfig.app.json` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6853fde0d55083238ac244603d3d1cd0