### PR TITLE
Add EventBus utility

### DIFF
--- a/libs/shared/hub/src/index.ts
+++ b/libs/shared/hub/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/event-bus';

--- a/libs/shared/hub/src/lib/event-bus.ts
+++ b/libs/shared/hub/src/lib/event-bus.ts
@@ -1,0 +1,65 @@
+export type EventHandler<T = any> = (payload: T) => void;
+
+/**
+ * EventBus implements a simple PubSub mechanism.
+ * It is a singleton so the same instance can be shared
+ * across the entire application.
+ */
+export class EventBus {
+    private static _instance: EventBus;
+    private subscribers = new Map<string, Set<EventHandler>>();
+
+    private constructor() {}
+
+    /**
+     * Returns the single instance of EventBus.
+     */
+    public static get instance(): EventBus {
+        if (!this._instance) {
+            this._instance = new EventBus();
+        }
+        return this._instance;
+    }
+
+    /**
+     * Subscribe to an event by name.
+     */
+    public subscribe<T>(event: string, handler: EventHandler<T>): void {
+        if (!this.subscribers.has(event)) {
+            this.subscribers.set(event, new Set());
+        }
+        this.subscribers.get(event)!.add(handler as EventHandler);
+    }
+
+    /**
+     * Unsubscribe from an event.
+     */
+    public unsubscribe<T>(event: string, handler: EventHandler<T>): void {
+        const handlers = this.subscribers.get(event);
+        if (handlers) {
+            handlers.delete(handler as EventHandler);
+            if (handlers.size === 0) {
+                this.subscribers.delete(event);
+            }
+        }
+    }
+
+    /**
+     * Publish an event to all subscribers.
+     */
+    public publish<T>(event: string, payload: T): void {
+        const handlers = this.subscribers.get(event);
+        if (handlers) {
+            handlers.forEach((h) => h(payload));
+        }
+    }
+
+    /**
+     * Clear all subscriptions. Useful for tests.
+     */
+    public clear(): void {
+        this.subscribers.clear();
+    }
+}
+
+export const eventBus = EventBus.instance;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -26,7 +26,8 @@
             "shared/SharedButtonComponent": [
                 "apps/shared/src/app/components/button.component.ts"
             ],
-            "styles": ["libs/shared/styles/src/index.ts"]
+            "styles": ["libs/shared/styles/src/index.ts"],
+            "hub": ["libs/shared/hub/src/index.ts"]
         }
     },
     "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
## Summary
- add a new shared hub with an `EventBus` singleton
- expose new `hub` alias in TypeScript config

## Testing
- `npx tsc -p tsconfig.base.json` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6853fae42f8483238b8264a6fb2970a9