### PR TITLE
Add Firebase auth guard and roles decorator

### DIFF
--- a/apps/auth/src/app/auth.controller.ts
+++ b/apps/auth/src/app/auth.controller.ts
@@ -4,9 +4,9 @@ import { Request } from 'express';
 
 @Controller()
 export class AuthController {
-  @Get('profile')
+  @Get('me')
   @UseGuards(FirebaseAuthGuard)
-  getProfile(@Req() req: Request) {
+  getMe(@Req() req: Request) {
     return (req as any).user;
   }
 }

--- a/apps/auth/src/app/roles.decorator.ts
+++ b/apps/auth/src/app/roles.decorator.ts
@@ -1,0 +1,3 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const Roles = (...roles: string[]) => SetMetadata('roles', roles);


### PR DESCRIPTION
## Summary
- add Firebase roles decorator for role-based checks
- update AuthController to expose `/me` endpoint protected by FirebaseAuthGuard

## Testing
- `npm install --ignore-scripts`
- `npx nx test auth`


------
https://chatgpt.com/codex/tasks/task_e_6854431a751083238c930e82cae7f076