### PR TITLE
Shorten directory tree listing

### DIFF
--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -1,0 +1,52 @@
+.
+├── apis
+│   ├── api-gateway
+│   │   └── src
+│   ├── api-gateway-e2e
+│   │   └── src
+│   ├── auth
+│   │   └── src
+│   ├── auth-e2e
+│   │   └── src
+│   ├── file-storage
+│   │   └── src
+│   ├── file-storage-e2e
+│   │   └── src
+│   ├── product
+│   │   └── src
+│   └── product-e2e
+│       └── src
+├── apps
+│   ├── auth-app
+│   │   ├── public
+│   │   └── src
+│   ├── auth-app-e2e
+│   │   └── src
+│   ├── cart
+│   │   └── src
+│   ├── product-app
+│   │   ├── public
+│   │   └── src
+│   ├── product-app-e2e
+│   │   └── src
+│   ├── shared
+│   │   ├── public
+│   │   └── src
+│   ├── storefront
+│   │   ├── public
+│   │   └── src
+│   └── storefront-e2e
+│       └── src
+├── libs
+│   └── shared
+│       ├── hub
+│       ├── styles
+│       └── ui
+├── scripts
+└── templates
+    └── organic-1.0.0
+        ├── css
+        ├── images
+        └── js
+
+50 directories


### PR DESCRIPTION
## Summary
- regenerate `STRUCTURE.md` using `tree -d` so only folder names appear
- update listing to reflect renamed folders in main branch

## Testing
- `tree -L 3 -d -I node_modules > STRUCTURE.md`


------
https://chatgpt.com/codex/tasks/task_e_68544ec66cc48323bea647ca249d80c3