### PR TITLE
Add remote fallback loader

### DIFF
--- a/apps/storefront/src/app/app.routes.ts
+++ b/apps/storefront/src/app/app.routes.ts
@@ -1,4 +1,5 @@
 import { Route } from '@angular/router';
+import { loadRemoteWithFallback } from 'hub';
 
 export const appRoutes: Route[] = [
     {
@@ -10,6 +11,13 @@ export const appRoutes: Route[] = [
         path: 'auth',
         loadChildren: () =>
             import('auth-app/Routes').then((m) => m.remoteRoutes),
+    },
+    {
+        path: 'products',
+        loadChildren: () =>
+            loadRemoteWithFallback('product-app', './ProductModule', () =>
+                import('./fallback/fallback-product.module').then((m) => m.FallbackProductModule)
+            ),
     },
     {
         path: '',

--- a/apps/storefront/src/app/fallback/fallback-product.module.ts
+++ b/apps/storefront/src/app/fallback/fallback-product.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'mfe-product-unavailable',
+  template: `Product App is currently unavailable. Please try again later.`,
+  standalone: true,
+  imports: [CommonModule],
+})
+export class ProductUnavailableComponent {}
+
+@NgModule({
+  imports: [ProductUnavailableComponent],
+  exports: [ProductUnavailableComponent],
+})
+export class FallbackProductModule {}

--- a/libs/shared/hub/src/index.ts
+++ b/libs/shared/hub/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/event-bus';
+export * from './lib/loadRemoteWithFallback';

--- a/libs/shared/hub/src/lib/loadRemoteWithFallback.ts
+++ b/libs/shared/hub/src/lib/loadRemoteWithFallback.ts
@@ -1,0 +1,13 @@
+export async function loadRemoteWithFallback<T>(
+  remote: string,
+  exposedModule: string,
+  fallback: () => Promise<T>
+): Promise<T> {
+  try {
+    const module = await import(/* webpackIgnore: true */ `${remote}/${exposedModule}`);
+    return module;
+  } catch (err) {
+    console.error(`Failed to load remote ${remote}/${exposedModule}`, err);
+    return fallback();
+  }
+}


### PR DESCRIPTION
## Summary
- define Angular fallback loader in `hub`
- show product fallback module
- add products route with fallback loader
- ensure remotes are listed in module federation config

## Testing
- `npx nx test storefront` *(fails: needs nx package installation)*

------
https://chatgpt.com/codex/tasks/task_e_685458297e04832397d123cc870ba9c9