### PR TITLE
Add fallback for best selling component

### DIFF
--- a/apps/storefront/src/app/fallback/best-selling-fallback.component.ts
+++ b/apps/storefront/src/app/fallback/best-selling-fallback.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+    selector: 'mfe-product-best-selling-unavailable',
+    standalone: true,
+    imports: [CommonModule],
+    template: `Best selling products are currently unavailable.`,
+})
+export class BestSellingFallbackComponent {}

--- a/apps/storefront/src/app/pages/dashboard/components/best-selling-wrapper.component.ts
+++ b/apps/storefront/src/app/pages/dashboard/components/best-selling-wrapper.component.ts
@@ -1,0 +1,29 @@
+import { Component, OnInit, Type } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { loadRemoteWithFallback } from 'hub';
+
+@Component({
+    selector: 'mfe-product-best-selling-section',
+    standalone: true,
+    imports: [CommonModule],
+    template: `<ng-container
+        *ngIf="component"
+        [ngComponentOutlet]="component"
+    ></ng-container>`,
+})
+export class BestSellingWrapperComponent implements OnInit {
+    component?: Type<unknown>;
+
+    async ngOnInit() {
+        const loaded = await loadRemoteWithFallback<any>(
+            'product-app',
+            './BestSellingFragment',
+            () =>
+                import('../../fallback/best-selling-fallback.component').then(
+                    (m) => m.BestSellingFallbackComponent,
+                ),
+        );
+
+        this.component = loaded.BestSellingComponent || loaded;
+    }
+}

--- a/apps/storefront/src/app/pages/dashboard/dashboard.component.ts
+++ b/apps/storefront/src/app/pages/dashboard/dashboard.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { HeroComponent } from './components/hero.component';
 import { CategoriesComponent } from './components/categories.component';
-import { BestSellingComponent } from 'product-app/BestSellingFragment';
+import { BestSellingWrapperComponent } from './components/best-selling-wrapper.component';
 import { BannerBlocksComponent } from './components/banner-blocks.component';
 import { FeaturedProductsComponent } from './components/featured-products.component';
 import { NewsletterComponent } from './components/newsletter.component';
@@ -23,7 +23,7 @@ import { SharedButtonComponent } from 'shared/SharedButtonComponent';
         CommonModule,
         HeroComponent,
         CategoriesComponent,
-        BestSellingComponent,
+        BestSellingWrapperComponent,
         BannerBlocksComponent,
         FeaturedProductsComponent,
         NewsletterComponent,
@@ -33,9 +33,8 @@ import { SharedButtonComponent } from 'shared/SharedButtonComponent';
         DownloadAppComponent,
         SearchTagsComponent,
         FeaturesComponent,
-        MfeButtonComponent
+        MfeButtonComponent,
     ],
-    templateUrl: './dashboard.component.html'
+    templateUrl: './dashboard.component.html',
 })
-export class DashboardComponent {
-}
+export class DashboardComponent {}


### PR DESCRIPTION
## Summary
- add a fallback best selling component to display when product app is unreachable
- load the remote BestSellingFragment with a fallback wrapper
- update dashboard module to use wrapper component

## Testing
- `npm test` *(fails: Missing script)*
- `npx nx format:check` *(fails: requires nx installation)*

------
https://chatgpt.com/codex/tasks/task_e_68545c9363a48323aac1b687e13f0a0a