### PR TITLE
Add cart event flow

### DIFF
--- a/apps/cart/src/app/components/cart.component.tsx
+++ b/apps/cart/src/app/components/cart.component.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
-
-export const CART_COUNT_EVENT = 'cart-count-change';
+import { CART_COUNT_EVENT } from 'hub';
 
 const CartComponent = () => {
   const [count, setCount] = useState(0);

--- a/apps/product-app/src/app/components/best-selling.component.ts
+++ b/apps/product-app/src/app/components/best-selling.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MfeButtonComponent } from 'shared-ui';
 import { ProductCardComponent } from './product-card.component';
+import { addCartItem } from 'hub';
 
 @Component({
   selector: 'mfe-product-best-selling-section',
@@ -74,6 +75,6 @@ export class BestSellingComponent {
   ];
 
   onAddToCart(product: any) {
-    console.log('Add to cart', product);
+    addCartItem(product);
   }
 }

--- a/apps/storefront/src/app/components/store-header/cart-button.component.ts
+++ b/apps/storefront/src/app/components/store-header/cart-button.component.ts
@@ -1,0 +1,26 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { CART_COUNT_EVENT, getCartCount } from 'hub';
+
+@Component({
+  selector: 'mfe-cart-button',
+  standalone: true,
+  imports: [CommonModule],
+  template: `<span class="badge bg-primary rounded-pill">{{ count }}</span>`
+})
+export class CartButtonComponent implements OnInit, OnDestroy {
+  count = 0;
+  private handler = (event: Event) => {
+    const detail = (event as CustomEvent).detail;
+    if (detail && typeof detail.count === 'number') {
+      this.count = detail.count;
+    }
+  };
+  ngOnInit(): void {
+    this.count = getCartCount();
+    window.addEventListener(CART_COUNT_EVENT, this.handler);
+  }
+  ngOnDestroy(): void {
+    window.removeEventListener(CART_COUNT_EVENT, this.handler);
+  }
+}

--- a/apps/storefront/src/app/components/store-header/header.component.html
+++ b/apps/storefront/src/app/components/store-header/header.component.html
@@ -75,6 +75,7 @@
                     <li>
                         <a href="#" class="p-2 mx-1" data-bs-toggle="offcanvas" data-bs-target="#offcanvasCart" aria-controls="offcanvasCart">
                             <svg width="24" height="24"><use xlink:href="#shopping-bag"></use></svg>
+                            <mfe-cart-button class="ms-1"></mfe-cart-button>
                         </a>
                     </li>
                 </ul>

--- a/apps/storefront/src/app/components/store-header/header.component.ts
+++ b/apps/storefront/src/app/components/store-header/header.component.ts
@@ -1,10 +1,16 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { CartButtonComponent } from './cart-button.component';
+import { initializeCartCount } from 'hub';
 
 @Component({
   selector: 'mfe-storefront-dashboard-header',
   standalone: true,
-    imports: [CommonModule],
+  imports: [CommonModule, CartButtonComponent],
   templateUrl: './header.component.html',
 })
-export class HeaderComponent {}
+export class HeaderComponent implements OnInit {
+  ngOnInit(): void {
+    initializeCartCount();
+  }
+}

--- a/libs/shared/hub/src/index.ts
+++ b/libs/shared/hub/src/index.ts
@@ -1,2 +1,3 @@
 export * from './lib/event-bus';
 export * from './lib/loadRemoteWithFallback';
+export * from './lib/cart-store';

--- a/libs/shared/hub/src/lib/cart-store.ts
+++ b/libs/shared/hub/src/lib/cart-store.ts
@@ -1,0 +1,34 @@
+export const CART_COUNT_EVENT = 'cart-count-change';
+const STORAGE_KEY = 'cart-items';
+export interface CartItem {
+  [key: string]: any;
+}
+
+export function getCartItems(): CartItem[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function getCartCount(): number {
+  return getCartItems().length;
+}
+
+export function broadcastCartCount(count: number) {
+  window.dispatchEvent(new CustomEvent(CART_COUNT_EVENT, { detail: { count } }));
+}
+
+export function addCartItem(item: CartItem): number {
+  const items = getCartItems();
+  items.push(item);
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+  broadcastCartCount(items.length);
+  return items.length;
+}
+
+export function initializeCartCount() {
+  broadcastCartCount(getCartCount());
+}


### PR DESCRIPTION
## Summary
- add `cart-store` util with localStorage and event helpers
- update shared hub index
- create `CartButtonComponent` and integrate it in header
- broadcast cart events from product app
- listen for cart events in React cart component

## Testing
- `npx nx test cart` *(fails: Need to install nx)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68545c9982d4832384b2366f84d9a15c