### PR TITLE
Add cart button count

### DIFF
--- a/apps/cart/src/app/components/cart-button.component.tsx
+++ b/apps/cart/src/app/components/cart-button.component.tsx
@@ -1,11 +1,44 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 
-const CartButton = () => (
-  <a className="p-2 mx-1" data-bs-toggle="offcanvas" data-bs-target="#offcanvasCart" aria-controls="offcanvasCart">
-    <svg width="24" height="24"><use xlinkHref="#shopping-bag"></use></svg>
-  </a>
-);
+const CART_KEY = 'cartItems';
+
+const CartButton = () => {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    const stored = JSON.parse(localStorage.getItem(CART_KEY) || '[]');
+    setCount(stored.length);
+
+    const handler = (e: any) => {
+      const items = JSON.parse(localStorage.getItem(CART_KEY) || '[]');
+      items.push(e.detail);
+      localStorage.setItem(CART_KEY, JSON.stringify(items));
+      setCount(items.length);
+    };
+
+    window.addEventListener('cart:add', handler);
+    return () => window.removeEventListener('cart:add', handler);
+  }, []);
+
+  return (
+    <a
+      className="p-2 mx-1 position-relative"
+      data-bs-toggle="offcanvas"
+      data-bs-target="#offcanvasCart"
+      aria-controls="offcanvasCart"
+    >
+      <svg width="24" height="24">
+        <use xlinkHref="#shopping-bag"></use>
+      </svg>
+      {count > 0 && (
+        <span className="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-primary">
+          {count}
+        </span>
+      )}
+    </a>
+  );
+};
 
 export function defineCartButtonElement() {
   class CartButtonElement extends HTMLElement {

--- a/apps/product-app/src/app/components/best-selling.component.ts
+++ b/apps/product-app/src/app/components/best-selling.component.ts
@@ -74,6 +74,8 @@ export class BestSellingComponent {
   ];
 
   onAddToCart(product: any) {
-    console.log('Add to cart', product);
+    window.dispatchEvent(
+      new CustomEvent('cart:add', { detail: product })
+    );
   }
 }


### PR DESCRIPTION
## Summary
- broadcast cart updates from product list
- display cart item count in CartButton
- persist cart items in localStorage

## Testing
- `npx --yes nx test cart` *(fails: Could not find Nx modules)*

------
https://chatgpt.com/codex/tasks/task_e_68546ecb8c308323b06aa463673daf15