### PR TITLE
Add product details navigation

### DIFF
--- a/apps/product-app/src/app/components/product-card.component.html
+++ b/apps/product-app/src/app/components/product-card.component.html
@@ -1,4 +1,4 @@
-<div class="product-item">
+<div class="product-item" (click)="viewDetails()">
   <figure>
     <a href="#" [title]="product.name">
       <img [src]="product.imageUrl" [alt]="product.name" class="tab-image" />

--- a/apps/product-app/src/app/components/product-card.component.spec.ts
+++ b/apps/product-app/src/app/components/product-card.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ProductCardComponent } from './product-card.component';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('ProductCardComponent', () => {
     let component: ProductCardComponent;
@@ -7,7 +8,7 @@ describe('ProductCardComponent', () => {
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            imports: [ProductCardComponent],
+            imports: [ProductCardComponent, RouterTestingModule],
         }).compileComponents();
 
         fixture = TestBed.createComponent(ProductCardComponent);
@@ -18,6 +19,7 @@ describe('ProductCardComponent', () => {
             imageUrl: '',
             price: 0,
         };
+        component.productId = '1';
         fixture.detectChanges();
     });
 

--- a/apps/product-app/src/app/components/product-card.component.ts
+++ b/apps/product-app/src/app/components/product-card.component.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, Input, Output, ViewEncapsulation } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { Router } from '@angular/router';
 
 @Component({
     selector: 'mfe-product-card',
@@ -10,10 +11,19 @@ import { CommonModule } from '@angular/common';
 })
 export class ProductCardComponent {
     @Input() product!: { name: string; description: string; imageUrl: string; price: number };
+    @Input() productId!: string | number;
     @Input() showAddToCart = true;
     @Output() addToCart = new EventEmitter<void>();
 
+    constructor(private readonly router: Router) {}
+
     onAddToCart() {
         this.addToCart.emit();
+    }
+
+    viewDetails() {
+        if (this.productId !== undefined && this.productId !== null) {
+            this.router.navigate(['/products', this.productId]);
+        }
     }
 }

--- a/apps/storefront/src/app/app.routes.ts
+++ b/apps/storefront/src/app/app.routes.ts
@@ -2,16 +2,21 @@ import { Route } from '@angular/router';
 import { loadRemoteWithFallback } from 'hub';
 
 export const appRoutes: Route[] = [
-    {
+  {
       path: 'pages',
       loadChildren: () =>
           import('./pages/pages.routes').then((c) => c.pagesRoutes)
-    },
-    {
-        path: 'auth',
-        loadChildren: () =>
-            import('auth-app/Routes').then((m) => m.remoteRoutes),
-    },
+  },
+  {
+      path: 'products/:id',
+      loadComponent: () =>
+          import('product-app/ProductDetailsPage').then((m) => m.ProductDetailsPage)
+  },
+  {
+      path: 'auth',
+      loadChildren: () =>
+          import('auth-app/Routes').then((m) => m.remoteRoutes),
+  },
     {
         path: '',
         redirectTo: 'pages',


### PR DESCRIPTION
## Summary
- enable router injection on product card and navigation method
- add product details route in storefront
- adjust product card tests for router

## Testing
- `npx nx test product-app` *(fails: Need to install nx)*

------
https://chatgpt.com/codex/tasks/task_e_68546fb60a808323b56eb163a798183e